### PR TITLE
Fix build, add explicit import of ts2kt.kotlin.ast.Function

### DIFF
--- a/src/TypeScriptToKotlinWalker.kt
+++ b/src/TypeScriptToKotlinWalker.kt
@@ -20,6 +20,7 @@ import typescript.*
 import ts2kt.utils.*
 import ts2kt.kotlin.ast.*
 import ts2kt.kotlin.ast
+import ts2kt.kotlin.ast.Function
 import kotlin.properties.Delegates
 import java.util.ArrayList
 import java.util.HashSet


### PR DESCRIPTION
Avoid ambiguity with the newly introduced built-in kotlin.Function, which is available in any Kotlin source via a default import