### PR TITLE
Include override modifier even if return types don't match.

### DIFF
--- a/src/runner/runner.kt
+++ b/src/runner/runner.kt
@@ -170,7 +170,7 @@ fun translate(srcPath: String): String {
     fun TS.TypeChecker.isOverride(candidate: TS.Signature, other: TS.Signature): Boolean {
         if (candidate.parameters.size != other.parameters.size) return false
 
-        if (!candidate.getReturnType().isSubtypeOf(other.getReturnType())) return false
+        // no need to check the return type.  If they are incompatible, It will be a Kotlin compilation error.
 
         for (i in candidate.parameters.indices) {
             val candidateType = getTypeOfSymbol(candidate.parameters[i])
@@ -210,12 +210,8 @@ fun translate(srcPath: String): String {
 
     fun isOverrideProperty(node: TS.PropertyDeclaration): Boolean {
         return isOverrideHelper(node) { typechecker, type, nodeName ->
-            val property = typechecker.getPropertyOfType(type, nodeName) ?: return@isOverrideHelper false
-
-            val candidateType = typechecker.getTypeAtLocation(node)
-            val otherType = typechecker.getTypeOfSymbol(property)
-
-            candidateType != null && candidateType.isSubtypeOf(otherType)
+            // no need to check the property type.  If they are incompatible, It will be a Kotlin compilation error.
+            return@isOverrideHelper typechecker.getPropertyOfType(type, nodeName) != null
         }
     }
 

--- a/testData/class/inheritance/overrides.d.kt
+++ b/testData/class/inheritance/overrides.d.kt
@@ -1,0 +1,22 @@
+package overrides
+
+@native
+interface Shape
+@native
+interface Box : Shape
+@native
+interface BaseEvent {
+    var data: dynamic /* String | Number */
+    fun getDelegateTarget(): Shape
+    fun getElement(): Element
+}
+@native
+open class BoxStringEvent : BaseEvent {
+    override var data: String = noImpl
+    override fun getDelegateTarget(): Box = noImpl
+    override fun getElement(): HTMLElement = noImpl
+}
+@native
+interface NumberEvent : BaseEvent {
+    override var data: Number
+}

--- a/testData/class/inheritance/overrides.d.ts
+++ b/testData/class/inheritance/overrides.d.ts
@@ -1,0 +1,17 @@
+declare interface Shape {}
+
+declare interface Box extends Shape {}
+
+declare interface BaseEvent {
+    data: string | number;
+    getDelegateTarget(): Shape;
+    getElement(): Element;
+}
+declare class BoxStringEvent implements BaseEvent {
+    data: string;
+    getDelegateTarget(): Box;
+    getElement(): HTMLElement;
+}
+declare interface NumberEvent extends BaseEvent {
+    data: number;
+}


### PR DESCRIPTION
There's no need to check the return type.
If they are incompatible, it will be a Kotlin compilation error.
This fixes a compilation error for reactive.
