### PR TITLE
Support type parameters for object literals.

### DIFF
--- a/src/TypeScriptToKotlinWalker.kt
+++ b/src/TypeScriptToKotlinWalker.kt
@@ -85,6 +85,8 @@ class TypeScriptToKotlinWalker(
         if (packageFqName != null) ObjectTypeToKotlinTypeMapperImpl.reset()
     }
 
+    private val typeParameterDeclarations = mutableListOf<TS.TypeParameterDeclaration>()
+
     override val result: KotlinFile
         get()  {
             assert(exportedByAssignment.isEmpty(), "exportedByAssignment should be empty, but it contains: ${exportedByAssignment.keys.toString()}")
@@ -95,7 +97,7 @@ class TypeScriptToKotlinWalker(
 
     val exportedByAssignment = hashMapOf<String, Annotation>()
 
-    val typeMapper = typeMapper ?: ObjectTypeToKotlinTypeMapperImpl(defaultAnnotations, declarations, typesByTypeAlias)
+    val typeMapper = typeMapper ?: ObjectTypeToKotlinTypeMapperImpl(defaultAnnotations, declarations, typesByTypeAlias, typeParameterDeclarations)
 
     fun addModule(qualifier: List<String>, name: String, members: List<Member>, additionalAnnotations: List<Annotation> = listOf()) {
         val annotations = DEFAULT_MODULE_ANNOTATION + additionalAnnotations

--- a/src/ast/typescript/typeScriptAstUtils.kt
+++ b/src/ast/typescript/typeScriptAstUtils.kt
@@ -142,14 +142,15 @@ fun TS.NodeArray<TS.TypeParameterDeclaration>.toKotlinTypeParams(typeMapper: Obj
         }
 
 fun TS.SignatureDeclaration.toKotlinCallSignatureOverloads(typeMapper: ObjectTypeToKotlinTypeMapper): List<CallSignature> {
-    return parameters.toKotlinParamsOverloads(typeMapper).map { params ->
-        toKotlinCallSignature(typeMapper, params)
-    }
+    val newTypeMapper = typeMapper.withTypeParameters(typeParameters)
+    val paramsOverloads = parameters.toKotlinParamsOverloads(newTypeMapper)
+    return paramsOverloads.map { toKotlinCallSignature(newTypeMapper, it) }
 }
 
 fun TS.SignatureDeclaration.toKotlinCallSignature(typeMapper: ObjectTypeToKotlinTypeMapper): CallSignature {
-    val params = parameters.toKotlinParams(typeMapper)
-    return toKotlinCallSignature(typeMapper, params)
+    val newTypeMapper = typeMapper.withTypeParameters(typeParameters)
+    val params = parameters.toKotlinParams(newTypeMapper)
+    return toKotlinCallSignature(newTypeMapper, params)
 }
 
 fun TS.SignatureDeclaration.toKotlinCallSignature(typeMapper: ObjectTypeToKotlinTypeMapper, params: List<FunParam>): CallSignature {

--- a/testData/objectType/functionTypedIntersectionParameter.d.kt
+++ b/testData/objectType/functionTypedIntersectionParameter.d.kt
@@ -1,0 +1,19 @@
+package functionTypedIntersectionParameter
+
+@native
+interface FooPart<T>
+@native
+interface `T$0`<T> {
+    var foo: T
+    var sup: Any
+}
+@native
+interface `T$1`<T> {
+    var foo: T
+    var bar: Any
+}
+@native
+open class FooTypedUnion {
+    open fun <T> baz(p: `T$0`<T>): Unit = noImpl
+    open fun <T> bar(p: `T$1`<T> /* `T$1`<T> & FooPart<T> */): Unit = noImpl
+}

--- a/testData/objectType/functionTypedIntersectionParameter.d.ts
+++ b/testData/objectType/functionTypedIntersectionParameter.d.ts
@@ -1,0 +1,8 @@
+declare interface FooPart<T> {}
+
+type FooPartAndLiteral<T> = {foo: T; bar;} & FooPart<T>
+
+declare class FooTypedUnion {
+    baz<T>(p: {foo: T; sup;});
+    bar<T>(p: FooPartAndLiteral<T>);
+}

--- a/testData/objectType/generics.d.kt
+++ b/testData/objectType/generics.d.kt
@@ -1,0 +1,40 @@
+package generics
+
+@native
+interface `T$0`<B> {
+    fun bar(a: Any): B
+}
+@native
+interface FooBazWithTypes<T> {
+    fun <B> returnsB(b: B): `T$0`<B>
+}
+@native
+interface `T$1`<T> {
+    fun bar(a: Any): T
+    var baz: Any? get() = noImpl; set(value){}
+    var boo: T? get() = noImpl; set(value){}
+    var show: (overrideChecks: Boolean) -> Unit
+}
+@native
+fun <T> withGenericObjectTypeParam(opt: `T$1`<T>): Unit = noImpl
+@native
+interface `T$2`<T> {
+    var a: T
+}
+@native
+interface `T$3`<T, S> {
+    fun bar(a: Any): T
+    fun foo(t: `T$2`<T>)
+    fun foo(t: String)
+    var baz: Any? get() = noImpl; set(value){}
+    var boo: S? get() = noImpl; set(value){}
+    var show: (overrideChecks: Boolean) -> Unit
+}
+@native
+fun <T, S> withDoublyGenericObjectTypeParam(opt: `T$3`<T, S>): Unit = noImpl
+@native
+interface `T$4`<S> {
+    fun bar(a: Any): S
+}
+@native
+fun <S> returnsGenericObjectType(): `T$4`<S> = noImpl

--- a/testData/objectType/generics.d.ts
+++ b/testData/objectType/generics.d.ts
@@ -1,0 +1,20 @@
+interface FooBazWithTypes<T> {
+    returnsB<B>(b: B): { bar(a): B };
+}
+declare function withGenericObjectTypeParam<T>(opt: {
+    bar(a): T;
+    baz?;
+    boo?: T;
+    show: (overrideChecks: boolean) => void;
+});
+declare function withDoublyGenericObjectTypeParam<T,S>(opt: {
+    bar(a): T;
+    foo(t: { a: T } | string)
+    baz?;
+    boo?: S;
+    show: (overrideChecks: boolean) => void;
+});
+
+declare function returnsGenericObjectType<S>(): {
+    bar(a): S;
+};


### PR DESCRIPTION
Rename Type to HeritageType.
Add an new 'Type' class and use it instead of String.