### PR TITLE
Fix testData compile errors.

### DIFF
--- a/src/ast/kotlin/ast.kt
+++ b/src/ast/kotlin/ast.kt
@@ -116,7 +116,7 @@ class KotlinFile(val packageFqName: Package?, val members: List<Member>) : Node(
 }
 
 class Package(val name: String) : Node() {
-    override fun stringify(): String = "package $name"
+    override fun stringify(): String = "package ${name.escapeIfNeed()}"
 }
 
 interface Named {

--- a/testData/class/generics/genericsWithConstraint.d.kt
+++ b/testData/class/generics/genericsWithConstraint.d.kt
@@ -1,10 +1,14 @@
 package genericsWithConstraint
 
 @native
-open class Foo<T : Bar> {
+interface Baz
+@native
+interface Bar
+@native
+open class FooBar<T : Bar> {
     open var varT: T = noImpl
     open fun withoutArgumentsReturnsT(): T = noImpl
     open fun withOneT(a: T): T = noImpl
     open fun <B : Baz> returnsB(a: Any): B = noImpl
-    open fun <A : T, B : B> withManyArguments(a: A, b: B): T = noImpl
+    open fun <A : T, B : Baz> withManyArguments(a: A, b: B): T = noImpl
 }

--- a/testData/class/generics/genericsWithConstraint.d.ts
+++ b/testData/class/generics/genericsWithConstraint.d.ts
@@ -1,7 +1,11 @@
-declare class Foo<T extends Bar> {
+declare interface Baz
+
+declare interface Bar
+
+declare class FooBar<T extends Bar> {
     varT: T;
     withoutArgumentsReturnsT(): T;
     withOneT(a: T): T;
     returnsB<B extends Baz>(a: any): B;
-    withManyArguments<A extends T, B extends B>(a: A, b: B): T;
+    withManyArguments<A extends T, B extends Baz>(a: A, b: B): T;
 }

--- a/testData/interface/generics/generics.d.kt
+++ b/testData/interface/generics/generics.d.kt
@@ -3,7 +3,7 @@ package generics
 @native
 interface ComponentSpec<P, S>
 @native
-interface Foo<T> {
+interface FooBaz<T> {
     var varT: T
     fun withoutArgumentsReturnsT(): T
     fun withOneT(a: T): T

--- a/testData/interface/generics/generics.d.ts
+++ b/testData/interface/generics/generics.d.ts
@@ -1,6 +1,6 @@
 interface ComponentSpec<P,S> {}
 
-interface Foo<T> {
+interface FooBaz<T> {
     varT: T;
     withoutArgumentsReturnsT(): T;
     withOneT(a: T): T;

--- a/testData/module/exportAssignment/exportFromExternalModule/class.d.kt
+++ b/testData/module/exportAssignment/exportFromExternalModule/class.d.kt
@@ -1,4 +1,4 @@
-package class
+package `class`
 
 @module("Boo")
 open class Klass {

--- a/testData/module/exportAssignment/exportFromExternalModule/var.d.kt
+++ b/testData/module/exportAssignment/exportFromExternalModule/var.d.kt
@@ -1,4 +1,4 @@
-package var
+package `var`
 
 @module
 object Mixto {

--- a/testData/objectType/var.d.kt
+++ b/testData/objectType/var.d.kt
@@ -1,4 +1,4 @@
-package var
+package `var`
 
 @native
 interface `T$0` {

--- a/ts2kt.iml
+++ b/ts2kt.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/testData" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/tools" />
     </content>


### PR DESCRIPTION
This doesn't fix the @module annotation, but that is all that isn't compiling.
Escape the package name if a reserved word.
Mark testData as test source so IntelliJ will indicate compilation failures.