### PR TITLE
Mark "typeof" as a word that needs escaping.

### DIFF
--- a/src/ast/typescript/typeScriptAstUtils.kt
+++ b/src/ast/typescript/typeScriptAstUtils.kt
@@ -40,7 +40,7 @@ val ARRAY = "Array"
 val SHOULD_BE_ESCAPED =
         setOf("as", "break", "class", "continue", "do", "else", "false", "for", "fun", "if",
               "in", "is", "null", "object", "package", "return", "super", "this", "This", "throw",
-              "trait", "true", "try", "typealias", "val", "var", "when", "while")
+              "trait", "true", "try", "typealias", "typeof", "val", "var", "when", "while")
 
 val NOT_OVERRIDE: (TS.Node) -> Boolean = { false }
 

--- a/testData/escaping.d.kt
+++ b/testData/escaping.d.kt
@@ -13,6 +13,7 @@ fun `fun`(): Unit = noImpl
 interface `This` {
     var `when`: String
     var `typealias`: Number
+    var `typeof`: Number
     fun `in`(`object`: Foo)
     companion object {
         var `$foo`: Boolean = noImpl

--- a/testData/escaping.d.ts
+++ b/testData/escaping.d.ts
@@ -6,6 +6,7 @@ declare function fun();
 interface This {
     when: string;
     typealias: number;
+    typeof: number;
     in(object: Foo);
 }
 declare class is<trait> {


### PR DESCRIPTION
It was causing a compilation failure after converting react.d.ts.