### PR TITLE
Add and use TypeAlias & TypeUnion to handle aliases with type-params.

### DIFF
--- a/src/ast/typescript/typeScriptAstUtils.kt
+++ b/src/ast/typescript/typeScriptAstUtils.kt
@@ -183,18 +183,19 @@ private fun TS.FunctionOrConstructorTypeNode.toKotlinTypeOverloads(typeMapper: O
 private fun TS.TypeLiteralNode.toKotlinType(typeMapper: ObjectTypeToKotlinTypeMapper): Type =
         typeMapper.getKotlinTypeForObjectType(this)
 
-private fun TS.TypeNode.toKotlinTypeOverloadsIfStandardType(typeMapper: ObjectTypeToKotlinTypeMapper): List<Type> {
+fun TS.TypeNode.toKotlinTypeOverloads(typeMapper: ObjectTypeToKotlinTypeMapper): List<Type> {
     return when (this.kind) {
         TS.SyntaxKind.ConstructorType,
         TS.SyntaxKind.FunctionType -> (this.cast<TS.FunctionOrConstructorTypeNode>()).toKotlinTypeOverloads(typeMapper)
 
-        TS.SyntaxKind.TypeReference -> (this.cast<TS.TypeReferenceNode>()).toKotlinTypeNameOverloads(typeMapper)
+        TS.SyntaxKind.TypeReference -> (this.cast<TS.TypeReferenceNode>()).toKotlinTypeOverloads(typeMapper)
         TS.SyntaxKind.UnionType -> (this.cast<TS.UnionTypeNode>()).toKotlinTypeOverloads(typeMapper)
-        else -> listOf(toKotlinTypeIfStandardType(typeMapper))
+        else -> listOf(toKotlinType(typeMapper))
     }
 }
 
-private fun TS.TypeNode.toKotlinTypeIfStandardType(typeMapper: ObjectTypeToKotlinTypeMapper): Type {
+// TODO
+fun TS.TypeNode.toKotlinType(typeMapper: ObjectTypeToKotlinTypeMapper): Type {
     return when (this.kind) {
         TS.SyntaxKind.AnyKeyword -> Type(ANY)
         TS.SyntaxKind.NumberKeyword -> Type(NUMBER)
@@ -228,16 +229,6 @@ private fun TS.TypeNode.toKotlinTypeIfStandardType(typeMapper: ObjectTypeToKotli
     }
 }
 
-// TODO
-fun TS.TypeNode.toKotlinTypeOverloads(typeMapper: ObjectTypeToKotlinTypeMapper): List<Type> {
-    return this.toKotlinTypeOverloadsIfStandardType(typeMapper)
-}
-
-// TODO
-fun TS.TypeNode.toKotlinType(typeMapper: ObjectTypeToKotlinTypeMapper): Type {
-    return this.toKotlinTypeIfStandardType(typeMapper)
-}
-
 fun TS.EntityName.toKotlinTypeName(typeMapper: ObjectTypeToKotlinTypeMapper): String {
     return when (kind) {
         TS.SyntaxKind.Identifier ->
@@ -253,7 +244,7 @@ fun TS.TypeReferenceNode.toKotlinType(typeMapper: ObjectTypeToKotlinTypeMapper):
     return toKotlinTypeIgnoringTypeAliases(typeMapper)
 }
 
-fun TS.TypeReferenceNode.toKotlinTypeNameOverloads(typeMapper: ObjectTypeToKotlinTypeMapper): List<Type> {
+fun TS.TypeReferenceNode.toKotlinTypeOverloads(typeMapper: ObjectTypeToKotlinTypeMapper): List<Type> {
     val typeUsingAlias = typeMapper.getKotlinTypeForTypeAlias(typeName.text)?.toKotlinTypeOverloads(typeMapper)
     if (typeUsingAlias != null) return typeUsingAlias
     return listOf(toKotlinTypeIgnoringTypeAliases(typeMapper))

--- a/testData/objectType/functionTypedIntersectionParameter.d.kt
+++ b/testData/objectType/functionTypedIntersectionParameter.d.kt
@@ -5,15 +5,15 @@ interface FooPart<T>
 @native
 interface `T$0`<T> {
     var foo: T
-    var sup: Any
+    var bar: Any
 }
 @native
 interface `T$1`<T> {
     var foo: T
-    var bar: Any
+    var sup: Any
 }
 @native
 open class FooTypedUnion {
-    open fun <T> baz(p: `T$0`<T>): Unit = noImpl
-    open fun <T> bar(p: `T$1`<T> /* `T$1`<T> & FooPart<T> */): Unit = noImpl
+    open fun <T> baz(p: `T$1`<T>): Unit = noImpl
+    open fun <T> bar(p: `T$0`<T> /* `T$0`<T> & FooPart<T> */): Unit = noImpl
 }

--- a/testData/typeAlias/typeParams.d.kt
+++ b/testData/typeAlias/typeParams.d.kt
@@ -1,0 +1,28 @@
+package typeParams
+
+@native
+var fooMap: Map<String, List<Number>> = noImpl
+@native
+fun mapKey(a: Map<Number, List<String>>): Unit = noImpl
+@native
+var fooStringOrMap: dynamic /* String | Map<String, List<Number>> */ = noImpl
+@native
+fun stringOrMapKey(a: String): Unit = noImpl
+@native
+fun stringOrMapKey(a: Map<Number, List<String>>): Unit = noImpl
+@native
+var listOfStringOrNumber: dynamic /* String | List<dynamic /* String | Number */> */ = noImpl
+@native
+fun listOfNumberOrString(a: List<dynamic /* Number | String */>): Unit = noImpl
+@native
+var headers: Map<String, List<String>> = noImpl
+@native
+fun getHeaders(): Map<String, List<String>> = noImpl
+@native
+fun addHeaders(headers: Map<String, List<String>>): Unit = noImpl
+@native
+var someRef: dynamic /* String | (instance: T) -> Any */ = noImpl
+@native
+fun addRef(ref: String): Unit = noImpl
+@native
+fun addRef(ref: (instance: T) -> Any): Unit = noImpl

--- a/testData/typeAlias/typeParams.d.ts
+++ b/testData/typeAlias/typeParams.d.ts
@@ -1,0 +1,26 @@
+type Values<V> = List<V>;
+type MultiMap<K,V> = Map<K,Values<V>>;
+type Headers = MultiMap<String,String>
+type Ref<T> = string | ((instance: T) => any);
+
+declare var fooMap: MultiMap<string,number>;
+
+declare function mapKey(a: MultiMap<number,String>);
+
+declare var fooStringOrMap: string | MultiMap<string,number>;
+
+declare function stringOrMapKey(a: string | MultiMap<number,String>);
+
+declare var listOfStringOrNumber: string | List<string | number>;
+
+declare function listOfNumberOrString(a: List<number | String>);
+
+declare var headers: Headers;
+
+declare function getHeaders(): Headers;
+
+declare function addHeaders(headers: Headers);
+
+declare var someRef: Ref<number>;
+
+declare function addRef(ref: Ref<number>);

--- a/testData/typeAlias/unionTypeParams.d.kt
+++ b/testData/typeAlias/unionTypeParams.d.kt
@@ -1,0 +1,12 @@
+package unionTypeParams
+
+@native
+var aliasUnionVar: dynamic /* List<Number> | Map<String, List<Number>> */ = noImpl
+@native
+fun aliasUnionFunction(a: List<String>): Unit = noImpl
+@native
+fun aliasUnionFunction(a: Map<Number, List<String>>): Unit = noImpl
+@native
+var listOfUnionVar: List<dynamic /* String | Number */> = noImpl
+@native
+fun listOfUnionFunction(a: List<dynamic /* Number | String */>): Unit = noImpl

--- a/testData/typeAlias/unionTypeParams.d.ts
+++ b/testData/typeAlias/unionTypeParams.d.ts
@@ -1,0 +1,10 @@
+type Values<V> = List<V>;
+type ListOrMultiMap<K,V> = List<V> | Map<K,Values<V>>;
+
+declare var aliasUnionVar: ListOrMultiMap<string,number>;
+
+declare function aliasUnionFunction(a: ListOrMultiMap<number,String>);
+
+declare var listOfUnionVar: Values<string | number>;
+
+declare function listOfUnionFunction(a: Values<number | String>);


### PR DESCRIPTION
Also:
Move null/lambda checks out of toKotlinParam.
Combine ...IfStandardType methods and fix method names.